### PR TITLE
docs: document React/Next/Tailwind stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,41 @@
-# portifolio
+# Portfólio
 
-## Build Setup
+Projeto de portfólio pessoal desenvolvido com React e Next.js, estilizado com Tailwind CSS para apresentar trabalhos, experiências e habilidades em desenvolvimento web. O objetivo é centralizar os principais projetos e facilitar o contato com possíveis colaboradores ou recrutadores.
+
+## Objetivos
+
+- Expor projetos pessoais e profissionais de forma organizada.
+- Demonstrar domínio de tecnologias modernas do ecossistema JavaScript.
+- Disponibilizar um ponto de contato simples e direto.
+
+## Tecnologias
+
+O projeto é construído com as seguintes ferramentas:
+
+- [React](https://reactjs.org)
+- [Next.js](https://nextjs.org)
+- [Tailwind CSS](https://tailwindcss.com)
+- [Axios](https://axios-http.com)
+
+## Executando localmente
 
 ```bash
-# install dependencies
-$ yarn install
+# instalar dependências
+yarn install
 
-# serve with hot reload at localhost:3000
-$ yarn dev
+# iniciar servidor de desenvolvimento em localhost:3000
+yarn dev
 
-# build for production and launch server
-$ yarn build
-$ yarn start
+# gerar build de produção
+yarn build
 
-# generate static project
-$ yarn generate
+# iniciar servidor com a build de produção
+yarn start
 ```
 
-For detailed explanation on how things work, check out the [documentation](https://nuxtjs.org).
+## Demonstração
 
-## Special Directories
+![Pré-visualização do portfólio](static/img/bg-index-title.avif)
 
-You can create the following extra directories, some of which have special behaviors. Only `pages` is required; you can delete them if you don't want to use their functionality.
+Caso prefira, você pode acessar uma versão hospedada do projeto através do link: [Demonstração Online](https://trovarelli.github.io/portifolio/#experiencia).
 
-### `assets`
-
-The assets directory contains your uncompiled assets such as Stylus or Sass files, images, or fonts.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/assets).
-
-### `components`
-
-The components directory contains your Vue.js components. Components make up the different parts of your page and can be reused and imported into your pages, layouts and even other components.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/components).
-
-### `layouts`
-
-Layouts are a great help when you want to change the look and feel of your Nuxt app, whether you want to include a sidebar or have distinct layouts for mobile and desktop.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/layouts).
-
-
-### `pages`
-
-This directory contains your application views and routes. Nuxt will read all the `*.vue` files inside this directory and setup Vue Router automatically.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/get-started/routing).
-
-### `plugins`
-
-The plugins directory contains JavaScript plugins that you want to run before instantiating the root Vue.js Application. This is the place to add Vue plugins and to inject functions or constants. Every time you need to use `Vue.use()`, you should create a file in `plugins/` and add its path to plugins in `nuxt.config.js`.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/plugins).
-
-### `static`
-
-This directory contains your static files. Each file inside this directory is mapped to `/`.
-
-Example: `/static/robots.txt` is mapped as `/robots.txt`.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/static).
-
-### `store`
-
-This directory contains your Vuex store files. Creating a file in this directory automatically activates Vuex.
-
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/store).


### PR DESCRIPTION
## Summary
- update README to correctly state the stack is React with Next.js and Tailwind CSS
- include React, Next.js, Tailwind CSS, and Axios in the technologies list

## Testing
- `yarn install --frozen-lockfile` *(fails: RequestError 403)*
- `npx eslint --ext ".js,.vue" --ignore-path .gitignore .` *(fails: ESLint couldn't find the config "@nuxtjs")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1e276938832291137ecb00b9d737