### PR TITLE
feat: add dark/light theme with toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="pt-br">
+    <html lang="pt-br" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            (function() {
+              const theme = localStorage.getItem('theme');
+              const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              if (theme === 'dark' || (!theme && systemDark)) {
+                document.documentElement.classList.add('dark');
+              }
+            })();
+          `,
+          }}
+        />
+      </head>
       <body>
         <div className="max-w-6xl mx-auto px-4 py-8">{children}</div>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,14 +12,14 @@ export default function Page() {
     <div className="min-h-screen">
       <Header />
       <section className="mt-10 grid md:grid-cols-3 gap-6">
-        <div className="md:col-span-2 bg-zinc-900/60 ring-1 ring-zinc-800 rounded-2xl p-6">
+        <div className="md:col-span-2 bg-white dark:bg-slate-900/60 ring-1 ring-slate-200 dark:ring-slate-800 rounded-2xl p-6">
           <h2 className="text-lg font-medium mb-2">Olá! 👋</h2>
-          <p className="text-zinc-300 leading-relaxed">{profile.about}</p>
+          <p className="text-slate-600 dark:text-slate-300 leading-relaxed">{profile.about}</p>
           <div className="mt-4 flex flex-wrap gap-2">
             {profile.tech.map((t) => (
               <span
                 key={t}
-                className="text-xs px-2.5 py-1 rounded-full bg-zinc-950 ring-1 ring-zinc-800 text-zinc-300"
+                className="text-xs px-2.5 py-1 rounded-full bg-slate-200 dark:bg-slate-950 ring-1 ring-slate-300 dark:ring-slate-800 text-slate-600 dark:text-slate-400"
               >
                 {t}
               </span>
@@ -29,29 +29,29 @@ export default function Page() {
             <a
               href={profile.github}
               target="_blank"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-400 text-emerald-950 font-semibold hover:brightness-95"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-indigo-500 text-white font-semibold hover:brightness-95"
             >
               GitHub
             </a>
             <a
               href={profile.linkedin}
               target="_blank"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-zinc-900 ring-1 ring-zinc-700 hover:bg-zinc-800"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-200 dark:bg-slate-900 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800"
             >
               LinkedIn
             </a>
             <a
               href={profile.resumeUrl}
               target="_blank"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-zinc-900 ring-1 ring-zinc-700 hover:bg-zinc-800"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-200 dark:bg-slate-900 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800"
             >
               Currículo
             </a>
           </div>
         </div>
-        <div className="bg-zinc-900/60 ring-1 ring-zinc-800 rounded-2xl p-6">
+        <div className="bg-white dark:bg-slate-900/60 ring-1 ring-slate-200 dark:ring-slate-800 rounded-2xl p-6">
           <h3 className="text-base font-medium mb-3">Disponível para remoto</h3>
-          <ul className="space-y-2 text-zinc-300 text-sm">
+          <ul className="space-y-2 text-slate-600 dark:text-slate-300 text-sm">
             <li className="flex items-center gap-2">
               <Globe size={16} /> {profile.location}
             </li>
@@ -64,7 +64,7 @@ export default function Page() {
       <section id="projetos" className="mt-12">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-medium">Projetos em destaque</h2>
-          <span className="text-xs text-zinc-400">
+          <span className="text-xs text-slate-500 dark:text-slate-400">
             {projects.length} projetos
           </span>
         </div>
@@ -79,7 +79,7 @@ export default function Page() {
           <Briefcase size={18} />
           <h2 className="text-lg font-medium">Experiência</h2>
         </div>
-        <ol className="relative border-s border-zinc-800 ps-6 space-y-8">
+        <ol className="relative border-s border-slate-200 dark:border-slate-800 ps-6 space-y-8">
           {experiences.map((e) => (
             <ExperienceItem key={e.role} e={e} />
           ))}
@@ -87,28 +87,27 @@ export default function Page() {
       </section>
       <section id="contato" className="mt-12">
         <h2 className="text-lg font-medium mb-2">Contato</h2>
-        <p className="text-zinc-300 text-sm">
+        <p className="text-slate-600 dark:text-slate-300 text-sm">
           Aberto a propostas remotas. Me envie um e-mail ou mensagem no
           LinkedIn.
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <a
             href={`mailto:${profile.email}`}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-zinc-900 ring-1 ring-zinc-700 hover:bg-zinc-800"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-200 dark:bg-slate-900 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800"
           >
             E-mail
           </a>
           <a
             href={profile.linkedin}
             target="_blank"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-zinc-900 ring-1 ring-zinc-700 hover:bg-zinc-800"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-slate-200 dark:bg-slate-900 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800"
           >
             LinkedIn
           </a>
         </div>
       </section>
-
-      <footer className="mt-14 pb-6 text-zinc-500 text-sm">
+      <footer className="mt-14 pb-6 text-slate-500 dark:text-slate-400 text-sm">
         © {year} {profile.name}. Construído com Next.js + Tailwind.
       </footer>
     </div>

--- a/components/ExperienceItem.tsx
+++ b/components/ExperienceItem.tsx
@@ -3,12 +3,12 @@ import type { Experience } from "@/data/experience";
 export default function ExperienceItem({ e }: { e: Experience }) {
   return (
     <li className="ms-2 relative">
-      <div className="absolute -start-5 mt-1.5 w-3 h-3 rounded-full bg-emerald-400 ring-2 ring-emerald-900/60" />
+      <div className="absolute -start-5 mt-1.5 w-3 h-3 rounded-full bg-indigo-500 dark:bg-indigo-400 ring-2 ring-indigo-200 dark:ring-indigo-900/60" />
       <h3 className="font-semibold">
-        {e.role} • <span className="text-emerald-300/90">{e.company}</span>
+        {e.role} • <span className="text-indigo-600 dark:text-indigo-400">{e.company}</span>
       </h3>
-      <p className="text-xs text-zinc-400">{e.period}</p>
-      <ul className="list-disc ms-5 mt-2 text-sm text-zinc-300 space-y-1">
+      <p className="text-xs text-slate-500 dark:text-slate-400">{e.period}</p>
+      <ul className="list-disc ms-5 mt-2 text-sm text-slate-600 dark:text-slate-300 space-y-1">
         {e.bullets.map((b, i) => (
           <li key={i}>{b}</li>
         ))}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { profile } from "@/data/profile";
 import avatar from "@/public/avatar.png";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
   return (
@@ -12,35 +13,36 @@ export default function Header() {
           alt="Avatar"
           width={56}
           height={56}
-          className="rounded-full ring-1 ring-zinc-700 bg-zinc-800"
+          className="rounded-full ring-1 ring-slate-300 dark:ring-slate-700 bg-slate-200 dark:bg-slate-800"
           priority
         />
         <div>
           <h1 className="text-xl md:text-2xl font-semibold">{profile.name}</h1>
-          <p className="text-zinc-400 text-sm md:text-base">
+          <p className="text-slate-600 dark:text-slate-400 text-sm md:text-base">
             {profile.headline}
           </p>
         </div>
       </div>
-      <nav className="flex flex-wrap gap-2">
+      <nav className="flex flex-wrap items-center gap-2">
         <a
-          className="px-3 py-2 rounded-full bg-zinc-900/70 ring-1 ring-zinc-700 hover:bg-zinc-800 text-sm"
+          className="px-3 py-2 rounded-full bg-slate-200 dark:bg-slate-900/70 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800 text-sm"
           href="#projetos"
         >
           Projetos
         </a>
         <a
-          className="px-3 py-2 rounded-full bg-zinc-900/70 ring-1 ring-zinc-700 hover:bg-zinc-800 text-sm"
+          className="px-3 py-2 rounded-full bg-slate-200 dark:bg-slate-900/70 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800 text-sm"
           href="#experiencia"
         >
           Experiência
         </a>
         <a
-          className="px-3 py-2 rounded-full bg-zinc-900/70 ring-1 ring-zinc-700 hover:bg-zinc-800 text-sm"
+          className="px-3 py-2 rounded-full bg-slate-200 dark:bg-slate-900/70 ring-1 ring-slate-300 dark:ring-slate-700 hover:bg-slate-300 dark:hover:bg-slate-800 text-sm"
           href="#contato"
         >
           Contato
         </a>
+        <ThemeToggle />
       </nav>
     </header>
   );

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -3,24 +3,24 @@ import type { Project } from '@/data/projects'
 
 export default function ProjectCard({ p }: { p: Project }) {
   return (
-    <article className="bg-zinc-900/60 ring-1 ring-zinc-800 rounded-2xl p-5">
-      <div className="aspect-video rounded-xl bg-gradient-to-br from-zinc-800 to-zinc-900 ring-1 ring-zinc-800 mb-4" />
+    <article className="bg-white dark:bg-slate-900/60 ring-1 ring-slate-200 dark:ring-slate-800 rounded-2xl p-5">
+      <div className="aspect-video rounded-xl bg-gradient-to-br from-slate-200 to-slate-300 dark:from-slate-800 dark:to-slate-900 ring-1 ring-slate-200 dark:ring-slate-700 mb-4" />
       <h3 className="text-base font-semibold">{p.title}</h3>
-      <p className="text-sm text-zinc-300 mt-1">{p.description}</p>
+      <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">{p.description}</p>
       <div className="mt-3 flex flex-wrap gap-2">
         {p.stack.map((s) => (
-          <span key={s} className="text-[10px] px-2 py-1 rounded-full bg-zinc-950 ring-1 ring-zinc-800 text-zinc-400">
+          <span key={s} className="text-[10px] px-2 py-1 rounded-full bg-slate-200 dark:bg-slate-950 ring-1 ring-slate-300 dark:ring-slate-800 text-slate-600 dark:text-slate-400">
             {s}
           </span>
         ))}
       </div>
       <div className="mt-4 flex items-center gap-3">
         {p.live && p.live !== '#' && (
-          <a href={p.live} target="_blank" className="text-sm inline-flex items-center gap-1 hover:underline">
+          <a href={p.live} target="_blank" className="text-sm inline-flex items-center gap-1 hover:underline text-indigo-600 dark:text-indigo-400">
             Demo <ExternalLink size={14} />
           </a>
         )}
-        <a href={p.repo} target="_blank" className="text-sm inline-flex items-center gap-1 hover:underline">
+        <a href={p.repo} target="_blank" className="text-sm inline-flex items-center gap-1 hover:underline text-indigo-600 dark:text-indigo-400">
           Código <Github size={14} />
         </a>
       </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const dark = root.classList.contains("dark");
+    setIsDark(dark);
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = () => {
+    const root = document.documentElement;
+    root.classList.toggle("dark");
+    const dark = root.classList.contains("dark");
+    setIsDark(dark);
+    localStorage.setItem("theme", dark ? "dark" : "light");
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <button
+      aria-label="Alternar tema"
+      className="p-2 rounded-full bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-slate-200"
+      onClick={toggleTheme}
+    >
+      {isDark ? <Sun size={16} /> : <Moon size={16} />}
+    </button>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,10 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-}
-
-body {
-  @apply bg-zinc-950 text-zinc-50;
+@layer base {
+  :root {
+    color-scheme: light dark;
+  }
+  body {
+    @apply bg-slate-100 text-slate-800 dark:bg-slate-950 dark:text-slate-100;
+  }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 export default {
+  darkMode: 'class',
   content: [
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Summary
- add light and dark color palettes with slate neutrals and indigo accents
- add theme toggle with automatic detection of browser preference
- enable Tailwind dark mode class and base styles

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae59e6cad08322b4719267bd49fd49